### PR TITLE
Empty string does not cause error

### DIFF
--- a/lib/casing/camel/string.rb
+++ b/lib/casing/camel/string.rb
@@ -6,6 +6,7 @@ module Casing
         symbol_to_string ||= false
 
         return val unless include_values
+        return val if val.length == 0
 
         sym = val.is_a?(Symbol)
 

--- a/test/bench/strings.rb
+++ b/test/bench/strings.rb
@@ -31,5 +31,13 @@ require_relative 'bench_init'
 
       assert(converter.case?(converted))
     end
+
+    context "Receives an empty string" do
+      converted = converter.('')
+
+      test "Returns an empty string" do
+        assert(converted == '')
+      end
+    end
   end
 end


### PR DESCRIPTION
Currently, passing an empty string into the `Casing::Camel#call` method results in an error. This pull request changes that so it will return an empty string instead, and also provides test coverage for empty strings as inputs. 
