### PR TITLE
MRuby compatibility

### DIFF
--- a/lib/casing/camel/string.rb
+++ b/lib/casing/camel/string.rb
@@ -10,8 +10,9 @@ module Casing
 
         sym = val.is_a?(Symbol)
 
+        val = val.to_s
+
         converted = val
-          .to_s
           .chars.first.downcase +
             Pascal::String.(val)[1..-1]
 


### PR DESCRIPTION
Casing needs a small change necessary for MRuby compatibility. Because strings and symbols are so similar, Ruby's Symbol implements a lot of the same methods that String does. Under MRuby, a more limited set of methods is available on Symbols. So, I had to add an extra `to_s` in order for the library to function properly under MRuby.