### PR TITLE
Deprecated actuator removed

### DIFF
--- a/lib/casing/camel/array.rb
+++ b/lib/casing/camel/array.rb
@@ -9,7 +9,6 @@ module Casing
           Casing::Camel.(v, include_values: include_values, symbol_to_string: symbol_to_string)
         end
       end
-      class << self; alias :! :call; end # TODO: Remove deprecated actuator [Kelsey, Thu Oct 08 2015]
     end
   end
 end

--- a/lib/casing/camel/hash.rb
+++ b/lib/casing/camel/hash.rb
@@ -7,7 +7,6 @@ module Casing
 
         ::Hash[val.map { |k, v| [Casing::Camel.(k, include_values: true, symbol_to_string: symbol_to_string), Casing::Camel.(v, include_values: include_values, symbol_to_string: symbol_to_string)] }]
       end
-      class << self; alias :! :call; end # TODO: Remove deprecated actuator [Kelsey, Thu Oct 08 2015]
     end
   end
 end

--- a/lib/casing/camel/string.rb
+++ b/lib/casing/camel/string.rb
@@ -22,7 +22,6 @@ module Casing
 
         converted
       end
-      class << self; alias :! :call; end # TODO: Remove deprecated actuator [Kelsey, Thu Oct 08 2015]
     end
   end
 end

--- a/lib/casing/casing.rb
+++ b/lib/casing/casing.rb
@@ -20,11 +20,6 @@ module Casing
     end
   end
 
-  # TODO: Remove deprecated actuator [Kelsey, Thu Oct 08 2015]
-  def !(val, include_values: nil, symbol_to_string: nil)
-    call(val, include_values: include_values, symbol_to_string: symbol_to_string)
-  end
-
   def case?(val, include_values: nil, symbol_to_string: nil)
     include_values ||= false
     symbol_to_string ||= false

--- a/lib/casing/pascal/array.rb
+++ b/lib/casing/pascal/array.rb
@@ -4,7 +4,6 @@ module Casing
       def self.call(*)
         raise Casing::Error, "Array cannot be converted to pascal case"
       end
-      class << self; alias :! :call; end # TODO: Remove deprecated actuator [Kelsey, Thu Oct 08 2015]
     end
   end
 end

--- a/lib/casing/pascal/hash.rb
+++ b/lib/casing/pascal/hash.rb
@@ -4,7 +4,6 @@ module Casing
       def self.call(*)
         raise Casing::Error, "Hash cannot be converted to pascal case"
       end
-      class << self; alias :! :call; end # TODO: Remove deprecated actuator [Kelsey, Thu Oct 08 2015]
     end
   end
 end

--- a/lib/casing/pascal/string.rb
+++ b/lib/casing/pascal/string.rb
@@ -20,7 +20,6 @@ module Casing
 
         converted
       end
-      class << self; alias :! :call; end # TODO: Remove deprecated actuator [Kelsey, Thu Oct 08 2015]
     end
   end
 end

--- a/lib/casing/underscore/array.rb
+++ b/lib/casing/underscore/array.rb
@@ -9,7 +9,6 @@ module Casing
           Casing::Underscore.(v, include_values: include_values, symbol_to_string: symbol_to_string)
         end
       end
-      class << self; alias :! :call; end # TODO: Remove deprecated actuator [Kelsey, Thu Oct 08 2015]
     end
   end
 end

--- a/lib/casing/underscore/hash.rb
+++ b/lib/casing/underscore/hash.rb
@@ -7,7 +7,6 @@ module Casing
 
         ::Hash[val.map { |k, v| [Casing::Underscore.(k, include_values: true, symbol_to_string: symbol_to_string), Casing::Underscore.(v, include_values: include_values, symbol_to_string: symbol_to_string)] }]
       end
-      class << self; alias :! :call; end # TODO: Remove deprecated actuator [Kelsey, Thu Oct 08 2015]
     end
   end
 end

--- a/lib/casing/underscore/string.rb
+++ b/lib/casing/underscore/string.rb
@@ -23,7 +23,6 @@ module Casing
 
         converted
       end
-      class << self; alias :! :call; end # TODO: Remove deprecated actuator [Kelsey, Thu Oct 08 2015]
     end
   end
 end


### PR DESCRIPTION
Resolves [#71](https://github.com/eventide-project/eventide/issues/71) (Remove all legacy uses of ! as an object's actuator)